### PR TITLE
Accept a function as the URL in the ping-url check

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The `memory` type accepts some additional configuration:
 
 The `ping-url` type requires some additional configuration:
 
-  - `url`: The URL that the check should ping
+  - `url`: The URL that the check should ping. This accepts a string or a function that returns a string
   - `method`: The HTTP method to use when pinging the URL. Defaults to `"HEAD"`
 
 #### Check Type: TCP/IP

--- a/lib/check/ping-url.js
+++ b/lib/check/ping-url.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const Check = require('../check');
+const isFunction = require('lodash/isFunction');
 const isPlainObject = require('lodash/isPlainObject');
 const isString = require('lodash/isString');
 const request = require('request-promise-native');
@@ -31,7 +32,7 @@ module.exports = class PingUrlCheck extends Check {
 	 */
 	run() {
 		return request({
-			uri: this.options.url,
+			uri: (typeof this.options.url === 'function' ? this.options.url() : this.options.url),
 			method: this.options.method || 'HEAD',
 			resolveWithFullResponse: true,
 			timeout: this.options.interval
@@ -58,8 +59,8 @@ module.exports = class PingUrlCheck extends Check {
 		if (!isPlainObject(options)) {
 			return new TypeError('Options must be an object');
 		}
-		if (!isString(options.url) || !options.url.trim()) {
-			return new TypeError('Invalid option: url must be a non-empty string');
+		if (!isFunction(options.url) && (!isString(options.url) || !options.url.trim())) {
+			return new TypeError('Invalid option: url must be a non-empty string or a function');
 		}
 		return true;
 	}

--- a/test/unit/lib/check/ping-url.test.js
+++ b/test/unit/lib/check/ping-url.test.js
@@ -118,6 +118,28 @@ describe('lib/check/ping-url', () => {
 
 			});
 
+			describe('when `options.url` is a function', () => {
+
+				beforeEach(() => {
+					instance.ok = false;
+					instance.checkOutput = 'mock output';
+					request.reset();
+					instance.options.url = () => 'mock-url-from-function';
+					returnedPromise = instance.run();
+				});
+
+				it('calls `request` with the expected options', () => {
+					assert.calledOnce(request);
+					assert.calledWith(request, {
+						uri: 'mock-url-from-function',
+						method: 'MOCK',
+						resolveWithFullResponse: true,
+						timeout: instance.options.interval
+					});
+				});
+
+			});
+
 			describe('when the request fails', () => {
 				let requestError;
 
@@ -235,7 +257,7 @@ describe('lib/check/ping-url', () => {
 		describe('when `options` has an invalid `url` property', () => {
 
 			it('returns a descriptive error', () => {
-				const expectedErrorMessage = 'Invalid option: url must be a non-empty string';
+				const expectedErrorMessage = 'Invalid option: url must be a non-empty string or a function';
 				options.url = '';
 				returnValue = PingUrlCheck.validateOptions(options);
 				assert.instanceOf(returnValue, TypeError);
@@ -244,6 +266,19 @@ describe('lib/check/ping-url', () => {
 				returnValue = PingUrlCheck.validateOptions(options);
 				assert.instanceOf(returnValue, TypeError);
 				assert.strictEqual(returnValue.message, expectedErrorMessage, 'non-string');
+			});
+
+		});
+
+		describe('when `options.url` is a function', () => {
+
+			beforeEach(() => {
+				options.url = () => 'mock-url';
+				returnValue = PingUrlCheck.validateOptions(options);
+			});
+
+			it('returns `true`', () => {
+				assert.isTrue(returnValue);
 			});
 
 		});


### PR DESCRIPTION
This allows you to specify a function instead of a string in the
ping-url check. Sometimes the URL needs to be calculated at the time the
health check is run, for example if you want to include a cache-bust.

This is needed for the Image Service health checks, where we have to
cache-bust our Cloudinary requests to avoid hitting their cache.

E.g.

```js
const health = new HealthCheck({
    checks: [
        {
            type: 'ping-url',
            url: () => {
                // Cache-bust this URL every 5 minutes
                const cacheBustInterval = (5 * 60 * 1000);
                const cacheBust = new Date(Math.floor(Date.now() / cacheBustInterval) * cacheBustInterval).toISOString();
                return `https://example.com/?cachebust=${cacheBust}`;
            },
            severity: 1,
            // etc ...
        }
    ]
});
```