### PR TITLE
Ignore the first run of a CPU check

### DIFF
--- a/lib/check/cpu.js
+++ b/lib/check/cpu.js
@@ -39,14 +39,18 @@ module.exports = class CpuCheck extends Check {
 					this.checkOutput = error.message;
 					this.log.error(`Health check "${this.options.name}" failed: ${error.message}`);
 				} else {
+					// Use a >100% threshold for the first run to get around the fact
+					// that CPU spikes when starting a Node.js process
+					const threshold = (this.hasRun ? this.options.threshold : 101);
 					this.checkOutput = `${result.cpu}% used`;
-					if (result.cpu <= this.options.threshold) {
+					if (result.cpu <= threshold) {
 						this.ok = true;
 					} else {
 						this.ok = false;
 						this.log.error(`Health check "${this.options.name}" failed: ${this.checkOutput}`);
 					}
 				}
+				this.hasRun = true;
 				this.lastUpdated = new Date();
 				resolve();
 			});

--- a/test/unit/lib/check/cpu.test.js
+++ b/test/unit/lib/check/cpu.test.js
@@ -118,6 +118,7 @@ describe('lib/check/cpu', () => {
 					usage.mockUsage.cpu = 75;
 					instance.ok = true;
 					instance.checkOutput = '';
+					instance.hasRun = true;
 					usage.lookup.reset();
 					returnedPromise = instance.run();
 				});
@@ -149,6 +150,50 @@ describe('lib/check/cpu', () => {
 
 					it('logs that the usage failed', () => {
 						assert.calledWithExactly(log.error, `Health check "mock name" failed: ${usage.mockUsage.cpu}% used`);
+					});
+
+				});
+
+			});
+
+			describe('when the usage is above `threshold` percent but this is the first run', () => {
+
+				beforeEach(() => {
+					usage.mockUsage.cpu = 75;
+					instance.ok = false;
+					instance.checkOutput = 'mock output';
+					delete instance.hasRun;
+					usage.lookup.reset();
+					returnedPromise = instance.run();
+				});
+
+				describe('.then()', () => {
+					let resolvedValue;
+
+					beforeEach(() => {
+						return returnedPromise.then(value => {
+							resolvedValue = value;
+						});
+					});
+
+					it('resolves with nothing', () => {
+						assert.isUndefined(resolvedValue);
+					});
+
+					it('sets the `ok` property to `true`', () => {
+						assert.isTrue(instance.ok);
+					});
+
+					it('sets the `checkOutput` property to the percentage CPU usage', () => {
+						assert.strictEqual(instance.checkOutput, `${usage.mockUsage.cpu}% used`);
+					});
+
+					it('updates the `lastUpdated` property', () => {
+						assert.strictEqual(instance.lastUpdated, mockDate);
+					});
+
+					it('sets the `hasRun` property to `true`', () => {
+						assert.isTrue(instance.hasRun);
 					});
 
 				});


### PR DESCRIPTION
This is required because CPU usage for a Node.js process spikes
massively when it starts, which means we'd see failing health-check
alerts on every deploy/restart of an application.

This circumvents the problem by always passing the first run of a CPU
check, by setting the threshold to a number larger than 100%. After the
first run it will use the configured CPU threshold.