### PR TITLE
Fix the bypass first run logic

### DIFF
--- a/lib/check/cpu.js
+++ b/lib/check/cpu.js
@@ -39,11 +39,10 @@ module.exports = class CpuCheck extends Check {
 					this.checkOutput = error.message;
 					this.log.error(`Health check "${this.options.name}" failed: ${error.message}`);
 				} else {
-					// Use a >100% threshold for the first run to get around the fact
-					// that CPU spikes when starting a Node.js process
-					const threshold = (this.hasRun ? this.options.threshold : 101);
 					this.checkOutput = `${result.cpu}% used`;
-					if (result.cpu <= threshold) {
+					// Bypass the actual check for the first run, this is to get around
+					// the fact that CPU spikes when starting a Node.js process
+					if (!this.hasRun || result.cpu <= this.options.threshold) {
 						this.ok = true;
 					} else {
 						this.ok = false;


### PR DESCRIPTION
This didn't account for >100% spikes.