### PR TITLE
Allow adding of custom checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,34 @@ app.use(expressWebService({
 
 Get the health check output as an array that's safe for converting to JSON. You can use this if you don't intend on using the [Express Web Service] module.
 
+### `new HealthCheck.Check( [options] )`
+
+This class is used to create custom health checks. You'll need to extend this class in order to use it, and can pass instances directly into `HealthCheck` when you instantiate it. E.g.
+
+```js
+class MyHealthCheck extends HealthCheck.Check {
+
+    constructor(options) {
+        super(options);
+    }
+
+    // Must return a promise
+    run() {
+        return new Promise(resolve => {
+            // Must set these properties
+            this.ok = true;
+            this.checkOutput = '';
+            this.lastUpdated = new Date();
+            resolve();
+        });
+    }
+
+}
+```
+
+[See examples](#examples) for more information, or look through [`lib/check`](lib/check) for more classes which already extend the base Check class.
+
+
 ### Options
 
 The Health Check module can be configured with a variety of options, passed in as an object to the `HealthCheck` constructor. The available options are as follows:
@@ -152,6 +180,12 @@ You can find example implementations of health checks in the `examples` folder o
 
     ```sh
     node examples/basic
+    ```
+
+  - **Custom:** create and run some custom health checks:
+
+    ```sh
+    node examples/custom
     ```
 
 

--- a/example/custom/index.js
+++ b/example/custom/index.js
@@ -1,0 +1,96 @@
+'use strict';
+
+// Load the module (you would replace this with the
+// full module name: @financial-times/health-check)
+const HealthCheck = require('../..');
+
+// Function which returns a promise that resolves
+// or rejects randomly
+function randomPromise(failRate) {
+	return new Promise((resolve, reject) => {
+		if (Math.random() >= failRate) {
+			resolve();
+		} else {
+			reject(new Error('Random failure'));
+		}
+	});
+}
+
+// Create a custom health check class that fails intermittently
+// It's configurable with a `failRate` option, to demonstrate
+// how you can make reusable health checks
+class RandomFailingCheck extends HealthCheck.Check {
+
+	constructor(options) {
+		// Fail ~50% of the time by default
+		options.failRate = options.failRate || 0.5;
+		super(options);
+	}
+
+	// Must return a promise that does not reject
+	// So it's important to add a catch handler
+	run() {
+		return randomPromise(this.options.failRate)
+			.then(() => {
+				// Setting the `ok` property is how you indicate
+				// that the health check is passing or failing
+				this.ok = true;
+				this.checkOutput = '';
+				// You must always set the `lastUpdated` property
+				// to a new date
+				this.lastUpdated = new Date();
+			})
+			.catch(error => {
+				this.ok = false;
+				this.checkOutput = error.message;
+				this.lastUpdated = new Date();
+			});
+	}
+
+}
+
+// Create a health check object
+const health = new HealthCheck({
+	checks: [
+
+		new RandomFailingCheck({
+			interval: 1000,
+			id: 'random',
+			name: '50% random failure check',
+			severity: 1,
+			businessImpact: 'Things may not work',
+			technicalSummary: 'Something went wrong!',
+			panicGuide: 'Don\'t panic'
+		}),
+
+		new RandomFailingCheck({
+			interval: 1000,
+			failRate: 0.9,
+			id: 'random-2',
+			name: '90% random failure check',
+			severity: 1,
+			businessImpact: 'Things may not work',
+			technicalSummary: 'Something went wrong!',
+			panicGuide: 'Don\'t panic'
+		}),
+
+		new RandomFailingCheck({
+			interval: 1000,
+			failRate: 0.1,
+			id: 'random-3',
+			name: '10% random failure check',
+			severity: 1,
+			businessImpact: 'Things may not work',
+			technicalSummary: 'Something went wrong!',
+			panicGuide: 'Don\'t panic'
+		})
+
+	]
+});
+
+// Here we're just polling the health checker to
+// see if there are any changes. We output the
+// results every second just for this example
+setInterval(() => {
+	console.log(health);
+}, 1000);

--- a/lib/health-check.js
+++ b/lib/health-check.js
@@ -4,6 +4,7 @@
  */
 'use strict';
 
+const Check = require('./check');
 const CpuCheck = require('./check/cpu');
 const defaults = require('lodash/defaults');
 const DiskSpaceCheck = require('./check/disk-space');
@@ -27,6 +28,10 @@ module.exports = class HealthCheck {
 		this.options = defaults({}, options, HealthCheck.defaultOptions);
 		this.checkObjects = this.options.checks.map(checkOptions => {
 			checkOptions.log = this.options.log;
+
+			if (checkOptions instanceof HealthCheck.Check) {
+				return checkOptions;
+			}
 			if (!HealthCheck.checkTypeMap.has(checkOptions.type)) {
 				throw new TypeError(`Invalid check type: ${checkOptions.type}`);
 			}
@@ -102,3 +107,9 @@ module.exports.checkTypeMap = new Map([
 	['ping-url', PingUrlCheck],
 	['tcp-ip', TcpIpCheck]
 ]);
+
+/**
+ * HealthCheck Check class.
+ * @access public
+ */
+module.exports.Check = Check;

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   },
   "nyc": {
     "exclude": [
-        "coverage",
-        "example",
-        "test"
+      "coverage",
+      "example",
+      "test"
     ]
   }
 }

--- a/test/unit/lib/health-check.test.js
+++ b/test/unit/lib/health-check.test.js
@@ -341,6 +341,32 @@ describe('lib/health-check', () => {
 
 		});
 
+		describe('when a check is an instance of HealthCheck.Check', () => {
+			let checkInstance;
+
+			beforeEach(() => {
+				checkInstance = sinon.createStubInstance(Check);
+				options.checks = [checkInstance];
+				Check.reset();
+				instance = new HealthCheck(options);
+			});
+
+			it('does not create a Check for the configuration', () => {
+				assert.notCalled(Check);
+			});
+
+			it('adds a log property to the check', () => {
+				assert.strictEqual(checkInstance.log, log);
+			});
+
+			it('has a `checkObjects` property set to an array of the created checks', () => {
+				assert.deepEqual(instance.checkObjects, [
+					checkInstance
+				]);
+			});
+
+		});
+
 		describe('when a class does not exist for a given check type', () => {
 
 			beforeEach(() => {
@@ -381,6 +407,10 @@ describe('lib/health-check', () => {
 		assert.strictEqual(HealthCheck.checkTypeMap.get('memory'), MemoryCheck);
 		assert.strictEqual(HealthCheck.checkTypeMap.get('ping-url'), PingUrlCheck);
 		assert.strictEqual(HealthCheck.checkTypeMap.get('tcp-ip'), TcpIpCheck);
+	});
+
+	it('has a `Check` static property', () => {
+		assert.strictEqual(HealthCheck.Check, Check);
 	});
 
 });


### PR DESCRIPTION
We now expose the `Check` class, and accept instances of it when
configuring a health check. This allows users to create their own custom
health check classes.

This proved slightly difficult to document, so I've relied on an example
rather than documenting extensively.