### PR TITLE
Add the ability to stop all checks from running

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ app.use(expressWebService({
 
 Get the health check output as an array that's safe for converting to JSON. You can use this if you don't intend on using the [Express Web Service] module.
 
+#### `health.stop()`
+
+This stops all of the checks from running. This is useful if the health checks are keeping the Node.js process open and you need it to close. E.g. after integration tests.
+
+```js
+health.stop();
+```
+
 ### `new HealthCheck.Check( [options] )`
 
 This class is used to create custom health checks. You'll need to extend this class in order to use it, and can pass instances directly into `HealthCheck` when you instantiate it. E.g.

--- a/lib/check.js
+++ b/lib/check.js
@@ -56,7 +56,7 @@ module.exports = class Check {
 	 * @throws {Error} Will throw if the health check is already running.
 	 */
 	start() {
-		if (this._interval) {
+		if (this.isRunning()) {
 			throw new Error('The check has already been started');
 		}
 		this.run();
@@ -68,11 +68,19 @@ module.exports = class Check {
 	 * @throws {Error} Will throw if the health check is not running.
 	 */
 	stop() {
-		if (!this._interval) {
+		if (!this.isRunning()) {
 			throw new Error('The check has not been started');
 		}
 		clearInterval(this._interval);
 		delete this._interval;
+	}
+
+	/**
+	 * Check whether the check is currently running.
+	 * @returns {Boolean} Returns whether the check is running.
+	 */
+	isRunning() {
+		return Boolean(this._interval);
 	}
 
 	/**

--- a/lib/health-check.js
+++ b/lib/health-check.js
@@ -42,6 +42,18 @@ module.exports = class HealthCheck {
 	}
 
 	/**
+	 * Stop all of the checks from running, calling the `stop` method of each.
+	 * @returns {undefined}
+	 */
+	stop() {
+		this.checkObjects.forEach(check => {
+			if (check.isRunning()) {
+				check.stop();
+			}
+		});
+	}
+
+	/**
 	 * Get a health check function that's compatible with:
 	 * https://github.com/Financial-Times/express-web-service
 	 * @returns {Function} A function which returns a promise that resolves to the check data.

--- a/test/unit/lib/check.test.js
+++ b/test/unit/lib/check.test.js
@@ -131,6 +131,7 @@ describe('lib/check', () => {
 			beforeEach(() => {
 				intervalId = 'mock-interval-id';
 				sinon.stub(global, 'setInterval').returns(intervalId);
+				sinon.stub(instance, 'isRunning').returns(false);
 				boundRun = sinon.spy();
 				sinon.stub(Check.prototype, 'run');
 				sinon.stub(instance.run, 'bind').returns(boundRun);
@@ -159,7 +160,7 @@ describe('lib/check', () => {
 			describe('when the check has already been started', () => {
 
 				beforeEach(() => {
-					instance._interval = 'not-a-real-interval';
+					instance.isRunning.returns(true);
 				});
 
 				it('throws an error', () => {
@@ -178,6 +179,7 @@ describe('lib/check', () => {
 			let intervalId;
 
 			beforeEach(() => {
+				sinon.stub(instance, 'isRunning').returns(true);
 				instance._interval = intervalId = 'mock-interval-id';
 				sinon.stub(global, 'clearInterval');
 				instance.stop();
@@ -199,11 +201,37 @@ describe('lib/check', () => {
 			describe('when the check has not been started', () => {
 
 				beforeEach(() => {
-					delete instance._interval;
+					instance.isRunning.returns(false);
 				});
 
 				it('throws an error', () => {
 					assert.throws(() => instance.stop(), 'The check has not been started');
+				});
+
+			});
+
+		});
+
+		it('has an `isRunning` method', () => {
+			assert.isFunction(instance.isRunning);
+		});
+
+		describe('.isRunning()', () => {
+
+			describe('when the `_interval` property is set', () => {
+
+				it('returns `true`', () => {
+					instance._interval = 'mock-interval';
+					assert.isTrue(instance.isRunning());
+				});
+
+			});
+
+			describe('when the `_interval` property is not set', () => {
+
+				it('returns `false`', () => {
+					delete instance._interval;
+					assert.isFalse(instance.isRunning());
 				});
 
 			});

--- a/test/unit/lib/health-check.test.js
+++ b/test/unit/lib/health-check.test.js
@@ -119,6 +119,28 @@ describe('lib/health-check', () => {
 			assert.strictEqual(instance.log, options.log);
 		});
 
+		it('has a `stop` method', () => {
+			assert.isFunction(instance.stop);
+		});
+
+		describe('.stop()', () => {
+
+			beforeEach(() => {
+				instance.checkObjects[2].isRunning.returns(false);
+				instance.stop();
+			});
+
+			it('stops each check from running', () => {
+				assert.calledOnce(instance.checkObjects[0].isRunning);
+				assert.calledOnce(instance.checkObjects[0].stop);
+				assert.calledOnce(instance.checkObjects[1].isRunning);
+				assert.calledOnce(instance.checkObjects[1].stop);
+				assert.calledOnce(instance.checkObjects[2].isRunning);
+				assert.notCalled(instance.checkObjects[2].stop);
+			});
+
+		});
+
 		it('has a `checks` method', () => {
 			assert.isFunction(instance.checks);
 		});

--- a/test/unit/mock/check.mock.js
+++ b/test/unit/mock/check.mock.js
@@ -23,6 +23,7 @@ function Check(options) {
 
 		// Methods
 		inspect: sinon.stub(),
+		isRunning: sinon.stub().returns(true),
 		run: sinon.stub(),
 		start: sinon.stub(),
 		stop: sinon.stub(),


### PR DESCRIPTION
This is mostly useful in integration tests, where sometimes the health
checks can prevent the Node.js process from exiting after the tests have
run, as they set intervals.