### PR TITLE
Only load the pre-existing checks if they are used

### DIFF
--- a/lib/health-check.js
+++ b/lib/health-check.js
@@ -27,10 +27,10 @@ module.exports = class HealthCheck {
 			if (checkOptions instanceof HealthCheck.Check) {
 				return checkOptions;
 			}
-			if (!HealthCheck.checkTypeMap.has(checkOptions.type)) {
+			if (!Object.prototype.hasOwnProperty.call(HealthCheck.checkTypeMap,checkOptions.type)) {
 				throw new TypeError(`Invalid check type: ${checkOptions.type}`);
 			}
-			const CheckTypeClass = HealthCheck.checkTypeMap.get(checkOptions.type);
+			const CheckTypeClass = HealthCheck.checkTypeMap[checkOptions.type];
 			return new CheckTypeClass(checkOptions);
 		});
 		this.log = this.options.log;
@@ -107,13 +107,23 @@ module.exports.defaultOptions = {
  * HealthCheck type to class map.
  * @access private
  */
-module.exports.checkTypeMap = new Map([
-	['cpu', () => require('./check/cpu')],
-	['disk-space', () => require('./check/disk-space')],
-	['memory', () => require('./check/memory')],
-	['ping-url', () => require('./check/ping-url')],
-	['tcp-ip', () => require('./check/tcp-ip')]
-]);
+module.exports.checkTypeMap = {
+	get 'cpu' () {
+		return require('./check/cpu');
+	},
+	get 'disk-space' () {
+		return require('./check/disk-space');
+	},
+	get 'memory' () {
+		return require('./check/memory');
+	},
+	get 'ping-url' () {
+		return require('./check/ping-url');
+	},
+	get 'tcp-ip' () {
+		return require('./check/tcp-ip');
+	}
+};
 
 /**
  * HealthCheck Check class.

--- a/lib/health-check.js
+++ b/lib/health-check.js
@@ -5,12 +5,7 @@
 'use strict';
 
 const Check = require('./check');
-const CpuCheck = require('./check/cpu');
 const defaults = require('lodash/defaults');
-const DiskSpaceCheck = require('./check/disk-space');
-const MemoryCheck = require('./check/memory');
-const PingUrlCheck = require('./check/ping-url');
-const TcpIpCheck = require('./check/tcp-ip');
 
 /**
  * Class representing a set of health checks.
@@ -113,11 +108,11 @@ module.exports.defaultOptions = {
  * @access private
  */
 module.exports.checkTypeMap = new Map([
-	['cpu', CpuCheck],
-	['disk-space', DiskSpaceCheck],
-	['memory', MemoryCheck],
-	['ping-url', PingUrlCheck],
-	['tcp-ip', TcpIpCheck]
+	['cpu', () => require('./check/cpu')],
+	['disk-space', () => require('./check/disk-space')],
+	['memory', () => require('./check/memory')],
+	['ping-url', () => require('./check/ping-url')],
+	['tcp-ip', () => require('./check/tcp-ip')]
 ]);
 
 /**

--- a/test/unit/lib/health-check.test.js
+++ b/test/unit/lib/health-check.test.js
@@ -60,11 +60,11 @@ describe('lib/health-check', () => {
 			MockType1 = sinon.spy(Check);
 			MockType2 = sinon.spy(Check);
 			MockType3 = sinon.spy(Check);
-			HealthCheck.checkTypeMap = new Map([
-				['mock-type-1', MockType1],
-				['mock-type-2', MockType2],
-				['mock-type-3', MockType3]
-			]);
+			HealthCheck.checkTypeMap = {
+				'mock-type-1': MockType1,
+				'mock-type-2': MockType2,
+				'mock-type-3': MockType3
+			};
 			options = {
 				checks: [
 					{
@@ -423,12 +423,12 @@ describe('lib/health-check', () => {
 	});
 
 	it('has a `checkTypeMap` static property', () => {
-		assert.instanceOf(HealthCheck.checkTypeMap, Map);
-		assert.strictEqual(HealthCheck.checkTypeMap.get('cpu'), CpuCheck);
-		assert.strictEqual(HealthCheck.checkTypeMap.get('disk-space'), DiskSpaceCheck);
-		assert.strictEqual(HealthCheck.checkTypeMap.get('memory'), MemoryCheck);
-		assert.strictEqual(HealthCheck.checkTypeMap.get('ping-url'), PingUrlCheck);
-		assert.strictEqual(HealthCheck.checkTypeMap.get('tcp-ip'), TcpIpCheck);
+		assert.instanceOf(HealthCheck.checkTypeMap, Object);
+		assert.strictEqual(HealthCheck.checkTypeMap['cpu'], CpuCheck);
+		assert.strictEqual(HealthCheck.checkTypeMap['disk-space'], DiskSpaceCheck);
+		assert.strictEqual(HealthCheck.checkTypeMap['memory'], MemoryCheck);
+		assert.strictEqual(HealthCheck.checkTypeMap['ping-url'], PingUrlCheck);
+		assert.strictEqual(HealthCheck.checkTypeMap['tcp-ip'], TcpIpCheck);
 	});
 
 	it('has a `Check` static property', () => {


### PR DESCRIPTION
This will avoid loading extra code in environments with smaller memory such as AWS Lambda