### PR TITLE
Null = object

### DIFF
--- a/lib/check/graphite-threshold.js
+++ b/lib/check/graphite-threshold.js
@@ -86,7 +86,7 @@ module.exports = class GraphiteThresholdCheck extends Check {
 		if (!isFunction(options.url) && (!isString(options.url) || !options.url.trim())) {
 			return new TypeError('Invalid option: url must be a non-empty string');
 		}
-		if (typeof options.threshold !== 'number' && typeof options.threshold !== null) {
+		if (typeof options.threshold !== 'number' && options.threshold !== null) {
 			return new Error('You must set a numerical or null threshold');
 		}
 		if (!options.graphiteKey) {

--- a/lib/check/graphite-threshold.js
+++ b/lib/check/graphite-threshold.js
@@ -20,7 +20,7 @@ module.exports = class GraphiteThresholdCheck extends Check {
 	 * @param {String} [options.method=GET] - The method to use when calling the Graphite API.
 	 * @param {String} options.url - The URL to call when the health check runs.
 	 * @param {String} options.direction - The direction to check relative to the threshold.
-	 * @param {Number} options.threshold - A numerical threshold to check over or under, according to the direction option.
+	 * @param {Number} options.threshold - A numerical or null threshold to check over or under, according to the direction option.
 	 * @param {String} options.graphiteKey - The API key needed to make calls to Graphite. Set in your environment variables.
 	 * @throws {TypeError} Will throw if any options are invalid.
 	 */
@@ -86,8 +86,8 @@ module.exports = class GraphiteThresholdCheck extends Check {
 		if (!isFunction(options.url) && (!isString(options.url) || !options.url.trim())) {
 			return new TypeError('Invalid option: url must be a non-empty string');
 		}
-		if (typeof options.threshold !== 'number') {
-			return new Error('You must set a numerical threshold');
+		if (typeof options.threshold !== 'number' && typeof options.threshold !== null) {
+			return new Error('You must set a numerical or null threshold');
 		}
 		if (!options.graphiteKey) {
 			return new Error('You must set up your Graphite key in your environment variables.');

--- a/test/unit/lib/check/graphite-threshold.test.js
+++ b/test/unit/lib/check/graphite-threshold.test.js
@@ -420,7 +420,7 @@ describe('lib/check/graphite-threshold', () => {
 
 			it('returns a descriptive error', () => {
 				const expectedErrorMessage = 'You must set a numerical or null threshold';
-				options.threshold = null;
+				options.threshold = 'bananacompleted';
 				returnValue = GraphiteThresholdCheck.validateOptions(options);
 				assert.instanceOf(returnValue, Error);
 				assert.strictEqual(returnValue.message, expectedErrorMessage, 'invalid threshold');

--- a/test/unit/lib/check/graphite-threshold.test.js
+++ b/test/unit/lib/check/graphite-threshold.test.js
@@ -419,7 +419,7 @@ describe('lib/check/graphite-threshold', () => {
 		describe('when `options` has an invalid `threshold` property', () => {
 
 			it('returns a descriptive error', () => {
-				const expectedErrorMessage = 'You must set a numerical threshold';
+				const expectedErrorMessage = 'You must set a numerical or null threshold';
 				options.threshold = null;
 				returnValue = GraphiteThresholdCheck.validateOptions(options);
 				assert.instanceOf(returnValue, Error);


### PR DESCRIPTION
Fixing graphite health check to throw errors if threshold isn't `null`, rather than `typeof null` ¯\_(ツ)_/¯