### PR TITLE
Unreference the setInterval to allow the process to exit if there is nothing else in the event loop to process.

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -61,6 +61,7 @@ module.exports = class Check {
 		}
 		this.run();
 		this._interval = setInterval(this.run.bind(this), this.options.interval);
+		this._interval.unref();
 	}
 
 	/**

--- a/test/unit/lib/check.test.js
+++ b/test/unit/lib/check.test.js
@@ -129,7 +129,8 @@ describe('lib/check', () => {
 			let boundRun;
 
 			beforeEach(() => {
-				intervalId = 'mock-interval-id';
+				intervalId = {};
+				intervalId.unref = sinon.spy();
 				sinon.stub(global, 'setInterval').returns(intervalId);
 				sinon.stub(instance, 'isRunning').returns(false);
 				boundRun = sinon.spy();
@@ -144,6 +145,10 @@ describe('lib/check', () => {
 
 			it('calls the `run` method', () => {
 				assert.calledOnce(instance.run);
+			});
+			
+			it('calls the `unref` method on the interval', () => {
+				assert.calledOnce(intervalId.unref);
 			});
 
 			it('Sets an interval with `options.interval` and a bound version of the `run` method', () => {
@@ -180,7 +185,7 @@ describe('lib/check', () => {
 
 			beforeEach(() => {
 				sinon.stub(instance, 'isRunning').returns(true);
-				instance._interval = intervalId = 'mock-interval-id';
+				instance._interval = intervalId = {};
 				sinon.stub(global, 'clearInterval');
 				instance.stop();
 			});

--- a/test/unit/lib/health-check.test.js
+++ b/test/unit/lib/health-check.test.js
@@ -4,7 +4,9 @@ const assert = require('proclaim');
 const mockery = require('mockery');
 const sinon = require('sinon');
 
-describe('lib/health-check', () => {
+describe('lib/health-check', function () {
+	this.timeout(10000);
+
 	let Check;
 	let CpuCheck;
 	let defaults;


### PR DESCRIPTION
Currently if something uses this package, it will never exit the process because this package creates a setInterval which will keep the process open forever 😔 