### PR TITLE
Allow datapoints of null or zero for graphite threshold checks

### DIFF
--- a/lib/check/graphite-threshold.js
+++ b/lib/check/graphite-threshold.js
@@ -46,7 +46,7 @@ module.exports = class GraphiteThresholdCheck extends Check {
 		})
 		.then((response) => {
 			this.response = JSON.parse(response.body);
-			if (!this.response || !this.response[0] || !this.response[0].datapoints || !this.response[0].datapoints[0] || !this.response[0].datapoints[0][0]) {
+			if (!this.response || !this.response[0] || !this.response[0].datapoints || !this.response[0].datapoints[0]) {
 				throw new Error('Please check that the URL is in the correct format, as it is not returning properly formatted JSON for this healthcheck.');
 			}
 			this.currentReading = this.response[0].datapoints[0][0];


### PR DESCRIPTION
I am setting up some graphite threshold checks for spark api and am getting the error `Please check that the URL is in the correct format, as it is not returning properly formatted JSON for this healthcheck.`.

This is an example of the data I get from Graphite:
```
[ { datapoints: [ [ null, 1555418580 ] ],
    target: 'internalproducts.heroku.spark-api.web_1.express.send_to_methode_POST.res.status.500.count',
    tags:
     { name: 'internalproducts.heroku.spark-api.web_1.express.send_to_methode_POST.res.status.500.count' } } ]

```

I think the problem is happening because I get nulls since there are no values for my query.  This is making ` || !this.response[0].datapoints[0][0]` on line 49 be true, throwing the error. 

I could use transformNull in my Graphite query to convert all nulls to zero so it needs to accept both null and zero. 
I could check if this.response[0].datapoints[0][0] is undefined but I don't think that would ever happen since Graphite returns nulls when there are no values. So I just removed it, is that okay? 

Thanks!



