### PR TITLE
Make graphite threshold check accept response when there is no data f…

### DIFF
--- a/lib/check/graphite-threshold.js
+++ b/lib/check/graphite-threshold.js
@@ -47,7 +47,7 @@ module.exports = class GraphiteThresholdCheck extends Check {
 		.then((response) => {
 			this.response = JSON.parse(response.body);
 
-			if (this.response.length) {
+			if (Array.isArray(this.response) && this.response.length) {
 				if (!this.response[0] || !this.response[0].datapoints || !this.response[0].datapoints[0]) {
 					throw new Error('Please check that the URL is in the correct format, as it is not returning properly formatted JSON for this healthcheck.');
 				}

--- a/lib/check/graphite-threshold.js
+++ b/lib/check/graphite-threshold.js
@@ -46,21 +46,24 @@ module.exports = class GraphiteThresholdCheck extends Check {
 		})
 		.then((response) => {
 			this.response = JSON.parse(response.body);
-			if (!this.response || !this.response[0] || !this.response[0].datapoints || !this.response[0].datapoints[0]) {
-				throw new Error('Please check that the URL is in the correct format, as it is not returning properly formatted JSON for this healthcheck.');
-			}
-			this.currentReading = this.response[0].datapoints[0][0];
-			if (this.direction === 'below') {
-				if (this.currentReading < this.threshold) {
-					this.ok = false;
-				} else {
-					this.ok = true;
+
+			if (this.response.length) {
+				if (!this.response[0] || !this.response[0].datapoints || !this.response[0].datapoints[0]) {
+					throw new Error('Please check that the URL is in the correct format, as it is not returning properly formatted JSON for this healthcheck.');
 				}
-			} else {
-				if (this.currentReading > this.threshold) {
-					this.ok = false;
+				this.currentReading = this.response[0].datapoints[0][0];
+				if (this.direction === 'below') {
+					if (this.currentReading < this.threshold) {
+						this.ok = false;
+					} else {
+						this.ok = true;
+					}
 				} else {
-					this.ok = true;
+					if (this.currentReading > this.threshold) {
+						this.ok = false;
+					} else {
+						this.ok = true;
+					}
 				}
 			}
 			this.checkOutput = '';

--- a/test/unit/lib/check/graphite-threshold.test.js
+++ b/test/unit/lib/check/graphite-threshold.test.js
@@ -42,10 +42,10 @@ describe('lib/check/graphite-threshold', () => {
 				name: 'mock name',
 				panicGuide: 'mock panic guide',
 				technicalSummary: 'mock technical summary',
-                url: 'mock-url',
-                threshold: 300,
-                direction: 'above',
-                graphiteKey: 'mock key'
+					url: 'mock-url',
+					threshold: 300,
+					direction: 'above',
+					graphiteKey: 'mock key'
 			};
 			sinon.stub(GraphiteThresholdCheck, 'assertOptionValidity');
 			startMock = sinon.stub(GraphiteThresholdCheck.prototype, 'start');
@@ -63,26 +63,26 @@ describe('lib/check/graphite-threshold', () => {
 		});
 
 		describe('.run()', () => {
-            let mockDate;
-            let returnedPromise;
-            let mockResponse;
+			let mockDate;
+			let returnedPromise;
+			let mockResponse;
 
 			beforeEach(() => {
 				mockDate = {
 					mock: true
 				};
-                sinon.stub(global, 'Date').returns(mockDate);
-                mockResponse = {
-                    body: JSON.stringify([
-                        { 'datapoints' : 
-                            [
-                                [300, 1542293760]
-                            ]
-                        }
-                    ])
+				sinon.stub(global, 'Date').returns(mockDate);
+				mockResponse = {
+					body: JSON.stringify([
+						{ 'datapoints' :
+							[
+								[300, 1542293760]
+							]
+						}
+					])
 				};
-                request.resolves(mockResponse);
-                instance.currentReading = '';
+				request.resolves(mockResponse);
+				instance.currentReading = '';
 				instance.ok = false;
 				instance.checkOutput = 'mock output';
 				returnedPromise = instance.run();
@@ -98,8 +98,8 @@ describe('lib/check/graphite-threshold', () => {
 					uri: 'mock-url',
 					method: 'MOCK',
 					resolveWithFullResponse: true,
-                    timeout: instance.options.interval,
-                    headers: { key: instance.options.graphiteKey }
+					timeout: instance.options.interval,
+					headers: { key: instance.options.graphiteKey }
 				});
 			});
 
@@ -109,14 +109,14 @@ describe('lib/check/graphite-threshold', () => {
 
 			describe('.then()', () => {
 
-                it('receives a response body', () => {
-                    assert.isObject(mockResponse);
-                });
+				it('receives a response body', () => {
+					assert.isObject(mockResponse);
+				});
 
-                it('receives a response body containing the correct text', () => {
-                    assert.deepEqual(mockResponse, {body: JSON.stringify([{'datapoints': [[300, 1542293760]]}])}, 'Response does not match set mock response');
-                });
-                
+				it('receives a response body containing the correct text', () => {
+					assert.deepEqual(mockResponse, {body: JSON.stringify([{'datapoints': [[300, 1542293760]]}])}, 'Response does not match set mock response');
+				});
+
 				it('sets the `checkOutput` property to an empty string', () => {
 					assert.strictEqual(instance.checkOutput, '');
 				});
@@ -126,17 +126,17 @@ describe('lib/check/graphite-threshold', () => {
 				});
 
 			});
-            
-            describe('for above - when the healthcheck passes `ok` is true', () => {
 
-                beforeEach(() => {
+			describe('for above - when the healthcheck passes `ok` is true', () => {
+
+				beforeEach(() => {
 					instance.ok = false;
 					instance.direction = 'above';
-                    instance.checkOutput = 'mock output';
-                    instance.threshold = 301;
+					instance.checkOutput = 'mock output';
+					instance.threshold = 301;
 					returnedPromise = instance.run();
 				});
-				
+
 				describe('.then()', () => {
 
 					beforeEach(() => {
@@ -146,22 +146,22 @@ describe('lib/check/graphite-threshold', () => {
 					it('checks that current reading is below the threshold and will pass health check', () => {
 						assert.ok(instance.currentReading < instance.threshold);
 					});
-					
+
 					it('sets the `ok` property to `true`', () => {
 						assert.isTrue(instance.ok);
 					});
 				});
-            });
+			});
 
-            describe('for above - when the healthcheck fails `ok` is false', () => {
+			describe('for above - when the healthcheck fails `ok` is false', () => {
 
-                beforeEach(() => {
+				beforeEach(() => {
 					instance.ok = true;
 					instance.direction = 'above';
-                    instance.checkOutput = 'mock output';
-                    instance.threshold = 299;
+					instance.checkOutput = 'mock output';
+					instance.threshold = 299;
 					returnedPromise = instance.run();
-                });
+				});
 
 				describe('.then()', () => {
 
@@ -172,7 +172,7 @@ describe('lib/check/graphite-threshold', () => {
 					it('checks that current reading is above the threshold and will fail health check', () => {
 						assert.ok(instance.currentReading > instance.threshold);
 					});
-					
+
 					it('sets the `ok` property to `false`', () => {
 						assert.isFalse(instance.ok);
 					});
@@ -183,14 +183,14 @@ describe('lib/check/graphite-threshold', () => {
 
 			describe('for below - when the healthcheck passes `ok` is true', () => {
 
-                beforeEach(() => {
+				beforeEach(() => {
 					instance.ok = false;
 					instance.checkOutput = 'mock output';
 					instance.direction = 'below';
-                    instance.threshold = 299;
+					instance.threshold = 299;
 					returnedPromise = instance.run();
 				});
-				
+
 				describe('.then()', () => {
 
 					beforeEach(() => {
@@ -200,22 +200,22 @@ describe('lib/check/graphite-threshold', () => {
 					it('checks that current reading is below the threshold and will pass health check', () => {
 						assert.ok(instance.currentReading > instance.threshold);
 					});
-					
+
 					it('sets the `ok` property to `true`', () => {
 						assert.isTrue(instance.ok);
 					});
 				});
-            });
+			});
 
-            describe('for below - when the healthcheck fails `ok` is false', () => {
+			describe('for below - when the healthcheck fails `ok` is false', () => {
 
-                beforeEach(() => {
+				beforeEach(() => {
 					instance.ok = true;
 					instance.checkOutput = 'mock output';
 					instance.direction = 'below';
-                    instance.threshold = 301;
+					instance.threshold = 301;
 					returnedPromise = instance.run();
-                });
+				});
 
 				describe('.then()', () => {
 
@@ -226,7 +226,7 @@ describe('lib/check/graphite-threshold', () => {
 					it('checks that current reading is above the threshold and will fail health check', () => {
 						assert.ok(instance.currentReading < instance.threshold);
 					});
-					
+
 					it('sets the `ok` property to `false`', () => {
 						assert.isFalse(instance.ok);
 					});
@@ -237,18 +237,18 @@ describe('lib/check/graphite-threshold', () => {
 
 			describe('for when the JSON response is malformed', () => {
 
-                beforeEach(() => {
+				beforeEach(() => {
 					instance.ok = true;
-					mockResponse.body = JSON.stringify([]);
+					mockResponse.body = JSON.stringify([{}]);
 					returnedPromise = instance.run();
-                });
+				});
 
 				describe('.then()', () => {
 
 					beforeEach(() => {
 						return returnedPromise;
 					});
-					
+
 					it('sets the `ok` property to `false`', () => {
 						assert.isFalse(instance.ok);
 					});
@@ -320,8 +320,8 @@ describe('lib/check/graphite-threshold', () => {
 						uri: 'mock-url',
 						method: 'GET',
 						resolveWithFullResponse: true,
-                        timeout: instance.options.interval,
-                        headers: { key: instance.options.graphiteKey }
+						timeout: instance.options.interval,
+						headers: { key: instance.options.graphiteKey }
 					});
 				});
 


### PR DESCRIPTION
…or the query


Hello, me again with another graphite threshold request :) 

I noticed that my health check for `https://graphitev2-api.ft.com/render/?format=json&from=-1min&target=internalproducts.heroku.spark-api.web_1.express.graphql_article_POST.res.status.400.count` is failing today. The query is returning `[]` whereas a couple of days ago it was returning datapoints of null.

I spoke to someone in the Infrastructure Delivery team and apparently “any metric that hasn’t received a datapoint for 8 days gets zapped”, so there is no longer anything in Graphite for `internalproducts.heroku.spark-api.web_1.express.graphql_article_POST.res.status.400.count`. I don’t think it will return until an error reoccurs. If I had used transformNull it wouldn’t have been deleted, but I guess in case anyone else forgets to use transformNull on a query that happens to return nulls for ages, it would be better to make the health check handle this situation.

Is there a better way of doing it? I just wanted to quickly stop my health check failing when it should be passing!