### PR TITLE
Remove the reference for the tcp-ip check so that it does not keep the process running if there is no other work needing to be done

### DIFF
--- a/lib/check/tcp-ip.js
+++ b/lib/check/tcp-ip.js
@@ -43,6 +43,10 @@ module.exports = class TcpIpCheck extends Check {
 				this.log.error(`Health check "${this.options.name}" failed: ${this.checkOutput}`);
 				resolve();
 			}, this.options.interval);
+			
+			if (timer.unref) {
+				timer.unref();
+			}
 
 			socket.on('connect', () => {
 				clearTimeout(timer);


### PR DESCRIPTION
Helps resolve https://github.com/Financial-Times/node-health-check/issues/19