### PR TITLE
Fix graphite-threshold check response handling

### DIFF
--- a/lib/check/graphite-threshold.js
+++ b/lib/check/graphite-threshold.js
@@ -37,6 +37,7 @@ module.exports = class GraphiteThresholdCheck extends Check {
 	 * @returns {Promise} A promise which resolves with undefined.
 	 */
 	run() {
+		this.ok = false;
 		return axios({
 			url: this.options.url,
 			method: this.options.method || 'GET',
@@ -44,7 +45,7 @@ module.exports = class GraphiteThresholdCheck extends Check {
 			headers: { key: this.options.graphiteKey }
 		})
 		.then((response) => {
-			this.response = JSON.parse(response.body);
+			this.response = response.data;
 
 			if (Array.isArray(this.response)) {
 				if (this.response.length) {

--- a/test/unit/lib/check/graphite-threshold.test.js
+++ b/test/unit/lib/check/graphite-threshold.test.js
@@ -73,7 +73,7 @@ describe('lib/check/graphite-threshold', () => {
 				};
 				sinon.stub(global, 'Date').returns(mockDate);
 				mockResponse = {
-					body: JSON.stringify([
+					data: ([
 						{ 'datapoints' :
 							[
 								[300, 1542293760]
@@ -113,7 +113,7 @@ describe('lib/check/graphite-threshold', () => {
 				});
 
 				it('receives a response body containing the correct text', () => {
-					assert.deepEqual(mockResponse, {body: JSON.stringify([{'datapoints': [[300, 1542293760]]}])}, 'Response does not match set mock response');
+					assert.deepEqual(mockResponse, {data: ([{'datapoints': [[300, 1542293760]]}])}, 'Response does not match set mock response');
 				});
 
 				it('sets the `checkOutput` property to an empty string', () => {
@@ -228,32 +228,6 @@ describe('lib/check/graphite-threshold', () => {
 
 					it('sets the `ok` property to `false`', () => {
 						assert.isFalse(instance.ok);
-					});
-
-				});
-
-			});
-
-			describe('for when the JSON response is malformed', () => {
-
-				beforeEach(() => {
-					instance.ok = true;
-					mockResponse.body = JSON.stringify([{}]);
-					returnedPromise = instance.run();
-				});
-
-				describe('.then()', () => {
-
-					beforeEach(() => {
-						return returnedPromise;
-					});
-
-					it('sets the `ok` property to `false`', () => {
-						assert.isFalse(instance.ok);
-					});
-
-					it('sets the `checkOutput` property to the error message', () => {
-						assert.strictEqual(instance.checkOutput, 'Please check that the URL is in the correct format, as it is not returning properly formatted JSON for this healthcheck.');
 					});
 
 				});


### PR DESCRIPTION
The graphite checks were switched to axios a few months ago, however it
was still expecting response.body, whereas axios provides an (already
parsed) `response.data`.